### PR TITLE
Add support for soft disabling a gateway

### DIFF
--- a/backend/src/main/kotlin/net/perfectdreams/perfectpayments/backend/config/AppConfig.kt
+++ b/backend/src/main/kotlin/net/perfectdreams/perfectpayments/backend/config/AppConfig.kt
@@ -9,7 +9,8 @@ data class AppConfig(
     val notificationToken: String,
     val database: DatabaseConfig,
     val website: WebsiteConfig,
-    val gateways: List<PaymentGateway>,
+    val gateways: Set<PaymentGateway>,
+    val softDisabledGateways: Set<PaymentGateway>,
     val tokens: List<TokenConfig>,
     val discordNotificationsWebhook: String? = null
 )

--- a/backend/src/main/kotlin/net/perfectdreams/perfectpayments/backend/routes/api/v1/GetAvailableGatewaysRoute.kt
+++ b/backend/src/main/kotlin/net/perfectdreams/perfectpayments/backend/routes/api/v1/GetAvailableGatewaysRoute.kt
@@ -9,6 +9,6 @@ import net.perfectdreams.sequins.ktor.BaseRoute
 
 class GetAvailableGatewaysRoute(val m: PerfectPayments) : BaseRoute("/api/v1/gateways") {
     override suspend fun onRequest(call: ApplicationCall) {
-        call.respondJson(Json.encodeToJsonElement(m.config.gateways))
+        call.respondJson(Json.encodeToJsonElement(m.config.gateways - m.config.softDisabledGateways))
     }
 }


### PR DESCRIPTION
The gateway is only disabled when serving the gateway via the API, but the payment callbacks are still set up correctly